### PR TITLE
add webhook annotations in order to populate caBundle from a cert-manager Certificate

### DIFF
--- a/helm-chart/kubemod/templates/job-crt/job-crt-create-secret.yaml
+++ b/helm-chart/kubemod/templates/job-crt/job-crt-create-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.job.true -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,3 +30,4 @@ spec:
         name: kubemod-crt
       restartPolicy: Never
       serviceAccountName: {{ include "kubemod.serviceAccountName" . }}-crt
+{{- end }}

--- a/helm-chart/kubemod/templates/job-crt/job-crt-create-secret.yaml
+++ b/helm-chart/kubemod/templates/job-crt/job-crt-create-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.job.true -}}
+{{- if .Values.job.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm-chart/kubemod/templates/job-crt/job-crt-patch-webhooks.yaml
+++ b/helm-chart/kubemod/templates/job-crt/job-crt-patch-webhooks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.job.true -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,3 +41,4 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ include "kubemod.fullname" . }}-crt-ca
+{{- end }}

--- a/helm-chart/kubemod/templates/job-crt/job-crt-patch-webhooks.yaml
+++ b/helm-chart/kubemod/templates/job-crt/job-crt-patch-webhooks.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.job.true -}}
+{{- if .Values.job.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm-chart/kubemod/templates/job-crt/role-crt.yaml
+++ b/helm-chart/kubemod/templates/job-crt/role-crt.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.job.true -}}
+{{- if .Values.job.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm-chart/kubemod/templates/job-crt/role-crt.yaml
+++ b/helm-chart/kubemod/templates/job-crt/role-crt.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.job.true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -85,3 +86,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kubemod.serviceAccountName" . }}-crt
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm-chart/kubemod/templates/job-crt/serviceaccount-crt.yaml
+++ b/helm-chart/kubemod/templates/job-crt/serviceaccount-crt.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.job.true -}}
+{{- if and .Values.serviceAccount.create .Values.job.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-chart/kubemod/templates/job-crt/serviceaccount-crt.yaml
+++ b/helm-chart/kubemod/templates/job-crt/serviceaccount-crt.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create .Values.job.true -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm-chart/kubemod/templates/mutatingwebhookconfiguration.yaml
+++ b/helm-chart/kubemod/templates/mutatingwebhookconfiguration.yaml
@@ -1,15 +1,27 @@
+{{- $caInjector := "" }}
+{{- range $k, $v := .Values.webhook.annotations }}
+{{- if has $k (list "cert-manager.io/inject-ca-from" "cert-manager.io/inject-ca-from-secret" "cert-manager.io/allow-direct-injection") }}
+{{- $caInjector = "true" }}
+{{- end }}
+{{- end }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "kubemod.fullname" . }}-mutating-webhook-configuration
   labels:
     {{- include "kubemod.labels" . | nindent 4 }}
+  {{- with .Values.webhook.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   creationTimestamp: null
 webhooks:
 - admissionReviewVersions:
   - v1beta1
   clientConfig:
+    {{- if ne $caInjector "true" }}
     caBundle: Cg==
+    {{- end }}
     service:
       name: {{ include "kubemod.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
@@ -31,7 +43,9 @@ webhooks:
 - admissionReviewVersions:
   - v1beta1
   clientConfig:
+    {{- if ne $caInjector "true" }}
     caBundle: Cg==
+    {{- end }}
     service:
       name: {{ include "kubemod.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}

--- a/helm-chart/kubemod/templates/validatingwebhookconfiguration.yaml
+++ b/helm-chart/kubemod/templates/validatingwebhookconfiguration.yaml
@@ -1,3 +1,9 @@
+{{- $caInjector := "" }}
+{{- range $k, $v := .Values.webhook.annotations }}
+{{- if has $k (list "cert-manager.io/inject-ca-from" "cert-manager.io/inject-ca-from-secret" "cert-manager.io/allow-direct-injection") }}
+{{- $caInjector = "true" }}
+{{- end }}
+{{- end }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -5,11 +11,17 @@ metadata:
   name: {{ include "kubemod.serviceAccountName" . }}-validating-webhook-configuration
   labels:
     {{- include "kubemod.labels" . | nindent 4 }}
+  {{- with .Values.webhook.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1beta1
   clientConfig:
+    {{- if ne $caInjector "true" }}
     caBundle: Cg==
+    {{- end }}
     service:
       name: {{ include "kubemod.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}

--- a/helm-chart/kubemod/values.yaml
+++ b/helm-chart/kubemod/values.yaml
@@ -7,13 +7,15 @@ replicaCount: 1
 image:
   repository: kubemod/kubemod
   pullPolicy: IfNotPresent
-  tag: "v0.13.0"
+  tag: "v0.14.0"
 
 job:
+  # Deploy the KubeMod certificate generation job
+  enabled: true
   image:
     repository: kubemod/kubemod-crt
     pullPolicy: IfNotPresent
-    tag: "v1.1.1"
+    tag: "v1.1.3"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -70,6 +72,11 @@ affinity: {}
 
 # MutatingWebhookConfiguration
 webhook:
+  # Specify webhook annotations
+  # Can be used to populate caBundle from a cert-manager Certificate.
+  # See https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-certificate-resource
+  annotations:
+    cert-manager.io/inject-ca-from-secret: kubemod-system/webhook-server-cert
   # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#mutatingwebhook-v1-admissionregistration-k8s-io
   failurePolicy: Ignore
   # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#labelselector-v1-meta

--- a/helm-chart/kubemod/values.yaml
+++ b/helm-chart/kubemod/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: kubemod/kubemod
   pullPolicy: IfNotPresent
-  tag: "v0.15.0-rc-1"
+  tag: "v0.15.0"
 
 job:
   # Deploy the KubeMod certificate generation job

--- a/helm-chart/kubemod/values.yaml
+++ b/helm-chart/kubemod/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: kubemod/kubemod
   pullPolicy: IfNotPresent
-  tag: "v0.14.0"
+  tag: "v0.15.0-rc-1"
 
 job:
   # Deploy the KubeMod certificate generation job
@@ -15,7 +15,7 @@ job:
   image:
     repository: kubemod/kubemod-crt
     pullPolicy: IfNotPresent
-    tag: "v1.1.3"
+    tag: "v1.2.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Hi,

Thanks for your work, this project is very interesting.

It's could be very cool if we manage Kubernetes Admission Webhook's certificates with cert-manager CA Injector.

You know what ? It's done :D

Below is an example of use (require argocd & cert-manager + ClusterIssuer) :
```
---
apiVersion: v1
kind: Namespace
metadata:
  labels:
    admission.kubemod.io/ignore: "true"
    control-plane: controller-manager
  name: kubemod-system
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: serving-cert
  namespace: kubemod-system
spec:
  dnsNames:
  - kubemod-webhook-service
  - kubemod-webhook-service.kubemod-system
  - kubemod-webhook-service.kubemod-system.svc
  - kubemod-webhook-service.kubemod-system.svc.cluster.local
  issuerRef:
    kind: ClusterIssuer
    name: selfsigned-cluster-issuer
  secretName: webhook-server-cert
---
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: kubemod
spec:
  project: kube-stack
  info:
  - name: artifacthub
    value: https://artifacthub.io/packages/helm/kubmod/kubemod
  - name: values.yaml
    value: https://github.com/kubemod/kubemod-helm/blob/main/helm-chart/kubemod/values.yaml
  - name: table-of-contents
    value: https://github.com/kubemod/kubemod#table-of-contents
  source:
    # chart: kubemod
    # repoURL: https://kubemod.github.io/kubemod-helm
    # targetRevision: v0.3.0
    repoURL: https://github.com/MalibuKoKo/kubemod-helm.git
    path: helm-chart/kubemod
    helm:
      releaseName: kubemod
      skipCrds: false
      values: |
        ---
        job:
          # Deploy the KubeMod certificate generation job
          enabled: false
        webhook:
          annotations:
            cert-manager.io/inject-ca-from: kubemod-system/serving-cert
        modrules:
        - name: add-label-color-blue
          namespace: kubemod-system
          spec:
            targetNamespaceRegex: .*
            match:
              - matchValue: Pod
                select: $.kind
            patch:
              - op: add
                path: /metadata/labels/color
                value: blue
            type: Patch
  destination:
    namespace: kubemod-system
    server: https://kubernetes.default.svc
```
